### PR TITLE
FIX Ensure the stage is set to Stage when importing to ensure sitetree imports are draft

### DIFF
--- a/code/StaticSiteImporter.php
+++ b/code/StaticSiteImporter.php
@@ -20,4 +20,19 @@ class StaticSiteImporter extends ExternalContentImporter {
 	public function getExternalType($item) {
 		return $item->getType();
 	}
+
+	/*
+	 * Switch to Stage to ensure imported content is added as Draft
+	 */
+    public function runOnImportStart() {
+		Versioned::reading_stage('Stage');
+	}
+
+	/*
+	 * Switch back to Live stage after import
+	 */
+	public function runOnImportEnd() {
+		Versioned::reading_stage('Live');
+	}
+
 }


### PR DESCRIPTION
Content ends up imported as whatever the current stage is set to (Live usually) which means the content in SiteTree ends up with no draft state and hidden from SiteTree (even if the import was successful).

It returns the stage to Live after import is complete just encase the importing user visits the frontend and sees all the content "Live".
